### PR TITLE
Align sidebar to the left by removing margin: auto from the body.

### DIFF
--- a/src/assets/styles/basics/_base.scss
+++ b/src/assets/styles/basics/_base.scss
@@ -17,7 +17,7 @@ body {
     font-size: rem(18px);
     margin: 0;
     max-width: 1024px;
-    margin: auto;
+    // margin: auto;
     background-color: $primary-bgc;
     color: $primary-color-1;
 }


### PR DESCRIPTION
Align sidebar to the left by removing margin: auto from the body according to the original Instagram layout look.